### PR TITLE
checkリストのAPIを叩く処理をsetTimeoutのデバウンス処理に変更した

### DIFF
--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+const AddListForm = ({closeModal, handleAddList}) => {
+  const [name, setName] = useState("");
+
+  return (
+    <>
+      <div className="bg-base-100 p-6 rounded-lg w-xl max-w-xl shadow-lg">
+        <h2 className="text-lg font-bold mb-1">新しい買い物リスト</h2>
+        <p className="text-sm text-neutral-500 mb-4">
+          買い物リストの名前を入力してください
+        </p>
+
+        <div className="mb-4">
+          <div>
+            <input
+              type="text"
+              className="input w-full"
+              placeholder="買い物リスト名"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 mt-4">
+          <button className="btn" onClick={closeModal}>
+            キャンセル
+          </button>
+          <button className="btn" onClick={() => handleAddList(name)}>
+            追加
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AddListForm

--- a/src/pages/ShoppingList/ShoppingList.jsx
+++ b/src/pages/ShoppingList/ShoppingList.jsx
@@ -1,11 +1,25 @@
 import { useState } from "react";
 import { Link, useLoaderData } from "react-router";
 import ShoppingCard from "../../components/ShoppingCard";
+import useModal from "../../hooks/useModal";
+import AddListForm from "../../components/AddListForm";
+import { api } from "../../utils/axios";
 
 const ShoppingList = () => {
 	const { shoppingLists } = useLoaderData();
 	const [lists, setLists] = useState(shoppingLists);
+	const { Modal, openModal, closeModal } = useModal();
 	console.log(lists);
+
+	const handleAddList = async (name) => {
+		try {
+			const response = await api.post(`/shopping_lists`,{ name });
+			console.log(response);
+			setLists((prev) => [...prev, response.data.data]);
+		} catch (err) {
+			console.error(err);
+		}
+	}
 
 	return (
 		<>
@@ -18,7 +32,7 @@ const ShoppingList = () => {
 					<p className="text-neutral-500">
 						複数の買い物リストを作成・管理できます
 					</p>
-					{/* <button className="btn btn-outline">新しいリスト</button> */}
+					<button className="btn btn-outline" onClick={openModal}>新しいリストの作成</button>
 				</div>
 
 				<div className="grid grid-cols-4 gap-4">
@@ -34,6 +48,9 @@ const ShoppingList = () => {
 					))}
 				</div>
 			</main>
+			<Modal>
+				<AddListForm closeModal={closeModal} handleAddList={handleAddList} />
+			</Modal>
 		</>
 	);
 };

--- a/src/pages/ShoppingListDetail/ShoppingListDetail.jsx
+++ b/src/pages/ShoppingListDetail/ShoppingListDetail.jsx
@@ -72,7 +72,7 @@ const ShoppingListDetail = () => {
 	}
 
 	useEffect(() => {
-		const timer = setInterval(async () => {
+		const timer = setTimeout(async () => {
 			if (changedItems.size === 0) return;
 
 			try {
@@ -88,10 +88,10 @@ const ShoppingListDetail = () => {
 				console.error(error);
 				setLoadingItems([]);
 			}
-		}, 5000);
+		}, 3000);
 
 
-		return () => clearInterval(timer);
+		return () => clearTimeout(timer);
 	}, [changedItems])
 
 	const handleAddItem = async (name, display_amount, category ) => {
@@ -126,7 +126,7 @@ const ShoppingListDetail = () => {
 				>
 					戻る
 				</button>
-				<button className="btn btn-outline" onClick={openModal}>
+				<button className="btn btn-outline btn-sm" onClick={openModal}>
 					アイテムを追加する
 				</button>
 			</div>


### PR DESCRIPTION
買い物リスト一覧に新しいリストの追加ボタンを実装して、
モーダルからリスト名の入力、APIを叩いてフロントはレスポンス情報をuseStateに渡す方式で
実装した。

また、買い物リストのチェック処理をdebounce処理に変更した（setIntervalからsetTimeoutへ）
動作はほぼ変わらないが、連続した変更のたびにAPIを叩かないように
5秒後に実施する、それまで他のチェックリストが変わった場合は古いsetTImeoutはclearTimeoutで中断される仕組み