### PR TITLE
レシピから買い物リストへの材料追加機能の実装完了

### DIFF
--- a/src/components/AddItemForm.jsx
+++ b/src/components/AddItemForm.jsx
@@ -25,12 +25,24 @@ const AddItemForm = ({ categories, closeModal, handleAddItem }) => {
 						/>
 					</div>
 					<div className="col-span-1">
-						<input type="text" className="input" placeholder="数量" value={amount} onChange={(e) => setAmount(e.target.value)} />
+						<input
+							type="text"
+							className="input"
+							placeholder="数量"
+							value={amount}
+							onChange={(e) => setAmount(e.target.value)}
+						/>
 					</div>
 				</div>
 
 				<div className="mb-4">
-					<select name="" id="" className="select" value={category} onChange={(e) => setCategory(e.target.value)}>
+					<select
+						name=""
+						id=""
+						className="select"
+						value={category}
+						onChange={(e) => setCategory(e.target.value)}
+					>
 						<option value="" className="text-neutral-500">
 							カテゴリーを選択
 						</option>
@@ -46,7 +58,10 @@ const AddItemForm = ({ categories, closeModal, handleAddItem }) => {
 					<button className="btn" onClick={closeModal}>
 						キャンセル
 					</button>
-					<button className="btn" onClick={() => handleAddItem(name, amount, category)}>
+					<button
+						className="btn"
+						onClick={() => handleAddItem(name, amount, category)}
+					>
 						追加
 					</button>
 				</div>

--- a/src/components/AddItemFromRecipe.jsx
+++ b/src/components/AddItemFromRecipe.jsx
@@ -1,0 +1,102 @@
+import { Check, Plus } from "lucide-react";
+import { useState } from "react";
+
+const AddLItemFromRecipe = ({
+	closeModal,
+	shoppingLists,
+	recipeName,
+	handleAddShoppingList,
+}) => {
+	const [isCreateMode, setIsCreateMode] = useState(false);
+	const [name, setName] = useState("");
+	return (
+		<>
+			<div className="bg-base-100 p-6 rounded-lg w-xl max-w-xl shadow-lg">
+				{isCreateMode ? (
+					<>
+						<h2 className="text-lg font-bold mb-1">新しい買い物リスト</h2>
+						<p className="text-sm text-neutral-500 mb-4">
+							買い物リストの名前を入力してください
+						</p>
+
+						<div className="mb-4">
+							<div>
+								<input
+									type="text"
+									className="input w-full"
+									placeholder="買い物リスト名"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+								/>
+							</div>
+						</div>
+
+						<div className="flex justify-end gap-2 mt-4">
+							<button className="btn" onClick={closeModal}>
+								キャンセル
+							</button>
+							<button
+								className="btn"
+								onClick={() => handleAddShoppingList({ name: name })}
+							>
+								作成して追加
+							</button>
+						</div>
+					</>
+				) : (
+					<>
+						<h2 className="text-lg font-bold mb-1">買い物リストを選択</h2>
+						<p className="text-sm text-neutral-500 mb-4">
+							{recipeName}の材料を全て追加する買い物リストを選択してください
+						</p>
+
+						<div className="flex flex-col space-y-2">
+							{shoppingLists.map((list) => (
+								<button
+									key={list.id}
+									className="btn btn-outline justify-between h-15 border-base-300"
+									onClick={() =>
+										handleAddShoppingList({ shoppingListId: list.id })
+									}
+									disabled={list.already_added}
+								>
+									<div className="text-left flex flex-start items-center space-x-2">
+										{list.already_added ? (
+											<Check size={15} />
+										) : (
+											<Plus size={15} />
+										)}
+										<div>
+											<div>{list.name}</div>
+											<div className="text-neutral-500">
+												{list.checked_count}/{list.items_count}完了
+											</div>
+										</div>
+									</div>
+									<div className="text-neutral-500">
+										最終更新：{list.updated}
+									</div>
+								</button>
+							))}
+							<button
+								className="btn btn-dash btn-primary h-15"
+								onClick={() => setIsCreateMode((prev) => !prev)}
+							>
+								<Plus size={15} />
+								新しいリストを作成
+							</button>
+						</div>
+
+						<div className="flex justify-end gap-2 mt-4">
+							<button className="btn" onClick={closeModal}>
+								キャンセル
+							</button>
+						</div>
+					</>
+				)}
+			</div>
+		</>
+	);
+};
+
+export default AddLItemFromRecipe;

--- a/src/components/AddListForm.jsx
+++ b/src/components/AddListForm.jsx
@@ -1,39 +1,39 @@
 import { useState } from "react";
 
-const AddListForm = ({closeModal, handleAddList}) => {
-  const [name, setName] = useState("");
+const AddListForm = ({ closeModal, handleAddList }) => {
+	const [name, setName] = useState("");
 
-  return (
-    <>
-      <div className="bg-base-100 p-6 rounded-lg w-xl max-w-xl shadow-lg">
-        <h2 className="text-lg font-bold mb-1">新しい買い物リスト</h2>
-        <p className="text-sm text-neutral-500 mb-4">
-          買い物リストの名前を入力してください
-        </p>
+	return (
+		<>
+			<div className="bg-base-100 p-6 rounded-lg w-xl max-w-xl shadow-lg">
+				<h2 className="text-lg font-bold mb-1">新しい買い物リスト</h2>
+				<p className="text-sm text-neutral-500 mb-4">
+					買い物リストの名前を入力してください
+				</p>
 
-        <div className="mb-4">
-          <div>
-            <input
-              type="text"
-              className="input w-full"
-              placeholder="買い物リスト名"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-        </div>
+				<div className="mb-4">
+					<div>
+						<input
+							type="text"
+							className="input w-full"
+							placeholder="買い物リスト名"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+						/>
+					</div>
+				</div>
 
-        <div className="flex justify-end gap-2 mt-4">
-          <button className="btn" onClick={closeModal}>
-            キャンセル
-          </button>
-          <button className="btn" onClick={() => handleAddList(name)}>
-            追加
-          </button>
-        </div>
-      </div>
-    </>
-  );
+				<div className="flex justify-end gap-2 mt-4">
+					<button className="btn" onClick={closeModal}>
+						キャンセル
+					</button>
+					<button className="btn" onClick={() => handleAddList(name)}>
+						追加
+					</button>
+				</div>
+			</div>
+		</>
+	);
 };
 
-export default AddListForm
+export default AddListForm;

--- a/src/pages/RecipesListDetail/RecipeListDetail.jsx
+++ b/src/pages/RecipesListDetail/RecipeListDetail.jsx
@@ -8,24 +8,30 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useLoaderData, useNavigate } from "react-router";
+import AddLItemFromRecipe from "../../components/AddItemFromRecipe";
 import Ingredients from "../../components/Ingredients";
 import RecipeSteps from "../../components/RecipeSteps";
+import useModal from "../../hooks/useModal";
 import { api } from "../../utils/axios";
 
 const RecipeListDetail = () => {
 	const { data } = useLoaderData();
+	const [shoppingList, setShoppingLists] = useState(data.attributes);
 	const navigate = useNavigate();
 	const [activeTab, setActiveTab] = useState("tab1");
+	const { Modal, openModal, closeModal } = useModal();
 	console.log(data);
 
-	const handleAddShoppingList = async () => {
+	const handleAddShoppingList = async ({ shoppingListId, name }) => {
 		try {
-			await api.post(`/shopping_lists/from_recipe`, {
+			const response = await api.post(`/shopping_lists/from_recipe`, {
 				recipe_id: data.id,
+				shopping_list_id: shoppingListId,
+				name: name,
 			});
-			alert("買い物リストを作成しました");
+			setShoppingLists(response.data.data.attributes);
 		} catch (error) {
-			console.log(error);
+			console.error(error);
 		}
 	};
 
@@ -45,20 +51,20 @@ const RecipeListDetail = () => {
 			<div className="mt-4 flex space-x-2 items-center">
 				<div className="flex items-center badge badge-secondary">
 					<Clock size={20} />
-					<span>調理時間 : {data.attributes.cooking_time}分</span>
+					<span>調理時間 : {shoppingList.cooking_time}分</span>
 				</div>
 				<div className="flex items-center badge badge-secondary">
 					<ChefHat size={20} />
-					<span>難易度 : {data.attributes.difficulty}</span>
+					<span>難易度 : {shoppingList.difficulty}</span>
 				</div>
 				<div className="flex items-center badge badge-secondary">
 					<User size={20} />
-					<span className="">材料 : {data.attributes.servings}人分</span>
+					<span className="">材料 : {shoppingList.servings}人分</span>
 				</div>
 			</div>
 
 			<div className="mt-10">
-				<button onClick={handleAddShoppingList} className="btn btn-primary">
+				<button onClick={openModal} className="btn btn-primary">
 					<ShoppingCart />
 					買い物リストに追加
 				</button>
@@ -85,15 +91,23 @@ const RecipeListDetail = () => {
 				<div>
 					{activeTab === "tab1" && (
 						<Ingredients
-							servings={data.attributes.servings}
-							ingredients={data.attributes.ingredients}
+							servings={shoppingList.servings}
+							ingredients={shoppingList.ingredients}
 						/>
 					)}
 					{activeTab === "tab2" && (
-						<RecipeSteps steps={data.attributes.recipe_steps} />
+						<RecipeSteps steps={shoppingList.recipe_steps} />
 					)}
 				</div>
 			</div>
+			<Modal>
+				<AddLItemFromRecipe
+					closeModal={closeModal}
+					shoppingLists={shoppingList.shopping_lists}
+					recipeName={data.attributes.name}
+					handleAddShoppingList={handleAddShoppingList}
+				/>
+			</Modal>
 		</main>
 	);
 };

--- a/src/pages/ShoppingList/ShoppingList.jsx
+++ b/src/pages/ShoppingList/ShoppingList.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Link, useLoaderData } from "react-router";
+import AddListForm from "../../components/AddListForm";
 import ShoppingCard from "../../components/ShoppingCard";
 import useModal from "../../hooks/useModal";
-import AddListForm from "../../components/AddListForm";
 import { api } from "../../utils/axios";
 
 const ShoppingList = () => {
@@ -13,13 +13,13 @@ const ShoppingList = () => {
 
 	const handleAddList = async (name) => {
 		try {
-			const response = await api.post(`/shopping_lists`,{ name });
+			const response = await api.post(`/shopping_lists`, { name });
 			console.log(response);
 			setLists((prev) => [...prev, response.data.data]);
 		} catch (err) {
 			console.error(err);
 		}
-	}
+	};
 
 	return (
 		<>
@@ -32,7 +32,9 @@ const ShoppingList = () => {
 					<p className="text-neutral-500">
 						複数の買い物リストを作成・管理できます
 					</p>
-					<button className="btn btn-outline" onClick={openModal}>新しいリストの作成</button>
+					<button className="btn btn-outline" onClick={openModal}>
+						新しいリストの作成
+					</button>
 				</div>
 
 				<div className="grid grid-cols-4 gap-4">

--- a/src/pages/ShoppingListDetail/ShoppingListDetail.jsx
+++ b/src/pages/ShoppingListDetail/ShoppingListDetail.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useLoaderData, useNavigate } from "react-router";
 import AddItemForm from "../../components/AddItemForm";
 import useModal from "../../hooks/useModal";
-import { api } from '../../utils/axios';
+import { api } from "../../utils/axios";
 
 const ShoppingListDetail = () => {
 	const { shoppingList } = useLoaderData();
@@ -18,7 +18,7 @@ const ShoppingListDetail = () => {
 	const [changedItems, setChangedItems] = useState(new Set());
 	const [loadingItems, setLoadingItems] = useState([]);
 	let filteredItems = items;
-	
+
 	console.log(shoppingList);
 
 	if (selectedCategory) {
@@ -64,12 +64,16 @@ const ShoppingListDetail = () => {
 	});
 
 	const handleClick = (item) => {
-		setItems((prev) => prev.map((preItem) => {
-			return preItem.id === item.id ? {...preItem, checked: !item.checked} : preItem
-		}));
+		setItems((prev) =>
+			prev.map((preItem) => {
+				return preItem.id === item.id
+					? { ...preItem, checked: !item.checked }
+					: preItem;
+			}),
+		);
 		setChangedItems((prev) => new Set(prev).add(item.item_id));
-		setLoadingItems((prev) => [...prev, item.id])
-	}
+		setLoadingItems((prev) => [...prev, item.id]);
+	};
 
 	useEffect(() => {
 		const timer = setTimeout(async () => {
@@ -80,8 +84,11 @@ const ShoppingListDetail = () => {
 					const item = items.find((i) => i.item_id === id);
 					return { id: item.item_id, checked: item.checked };
 				});
-				await api.patch(`/shopping_lists/${shoppingList.id}/shopping_list_items/batch_update`, { updates });
-				
+				await api.patch(
+					`/shopping_lists/${shoppingList.id}/shopping_list_items/batch_update`,
+					{ updates },
+				);
+
 				setChangedItems(new Set());
 				setLoadingItems([]);
 			} catch (error) {
@@ -90,32 +97,34 @@ const ShoppingListDetail = () => {
 			}
 		}, 3000);
 
-
 		return () => clearTimeout(timer);
-	}, [changedItems])
+	}, [changedItems]);
 
-	const handleAddItem = async (name, display_amount, category ) => {
+	const handleAddItem = async (name, display_amount, category) => {
 		try {
-			const response = await api.post(`/shopping_lists/${shoppingList.id}/shopping_list_items`, {
-				name, display_amount, category
-			});
+			const response = await api.post(
+				`/shopping_lists/${shoppingList.id}/shopping_list_items`,
+				{
+					name,
+					display_amount,
+					category,
+				},
+			);
 			console.log(response);
-			setItems((prev) => [...prev, {...response.data.item}])
+			setItems((prev) => [...prev, { ...response.data.item }]);
 		} catch (error) {
 			console.error(error);
 		}
-	}
+	};
 
 	const handleDeleteItem = async (id) => {
 		try {
-			await api.delete(`/shopping_list_items/${id}`)
-			setItems((prev) => prev.filter((item) => item.item_id !== id))
+			await api.delete(`/shopping_list_items/${id}`);
+			setItems((prev) => prev.filter((item) => item.item_id !== id));
 		} catch (error) {
 			console.error(error);
 		}
-	}
-
-
+	};
 
 	return (
 		<div className="container max-w-screen-md mx-auto px-4 py-8">
@@ -163,8 +172,7 @@ const ShoppingListDetail = () => {
 						<span
 							className={`badge ${check.length === items.length ? "badge-success" : "badge-outline badge-primary"}`}
 						>
-							{check.length}/{items.length}{" "}
-							完了
+							{check.length}/{items.length} 完了
 						</span>
 					</div>
 
@@ -173,7 +181,7 @@ const ShoppingListDetail = () => {
 					</p>
 
 					<div className="mt-4">
-												<p
+						<p
 							className={`text-secondary transition-opacity duration-500 ease-in ${items.length === check.length ? "opacity-100" : "opacity-0"}`}
 						>
 							すべての買い物が完了しました！
@@ -208,20 +216,23 @@ const ShoppingListDetail = () => {
 														/>
 														<div className="flex flex-col">
 															<label htmlFor="">{item.name}</label>
-															{ item.fromRecipe && (
-																	<span className="text-neutral-500 text-sm">
-																レシピ: {item.fromRecipe} 
-															</span>
+															{item.fromRecipe && (
+																<span className="text-neutral-500 text-sm">
+																	レシピ: {item.fromRecipe}
+																</span>
 															)}
 														</div>
 														{loadingItems.includes(item.id) && (
 															<span className="loading loading-spinner loading-xs ml-2"></span>
 														)}
-
 													</div>
 													<div className="flex items-center space-x-4">
 														<span>{item.display_amount}</span>
-														<Trash2 className="hover:text-error" size={15} onClick={() => handleDeleteItem(item.item_id)} />
+														<Trash2
+															className="hover:text-error"
+															size={15}
+															onClick={() => handleDeleteItem(item.item_id)}
+														/>
 													</div>
 												</div>
 											</li>
@@ -235,7 +246,11 @@ const ShoppingListDetail = () => {
 			</div>
 
 			<Modal>
-				<AddItemForm categories={preferredOrder} closeModal={closeModal} handleAddItem={handleAddItem} />
+				<AddItemForm
+					categories={preferredOrder}
+					closeModal={closeModal}
+					handleAddItem={handleAddItem}
+				/>
 			</Modal>
 		</div>
 	);


### PR DESCRIPTION
レシピの詳細ページの買い物リストに追加の機能で、追加先のリストを選択できるようにした。
買い物リストに追加をクリックするとモーダルが開き、作成されている買い物リストが表示される。
追加先のリストをクリックするとAPIを叩いてバックエンドから更新されたレシピ詳細ページのデータが
レスポンスされるので、useStateで最新データを改めて設定している。
それにより、already_addedのカラムがtrueになるため、追加済みのリストはdisabledで無効にしている。
（なお、一つでもレシピと紐づく材料があれば追加はできない）
また、新しいリストを作成をクリックするとisCreateModeのuseStateがtrueになり、
画面を切り替えている。
名前を入力して、作成して追加で、再度APIを叩く。
バックエンドでshopping_listを作成してレスポンスデータをセットは変わりない。
isCreateModeはbooleanのため、自動的に買い物リストを選択の画面に切り替わる。
（これは実装してから思い通りに動作してびっくり）