### PR TITLE
メールアドレス変更機能実装

### DIFF
--- a/src/components/EmailChangeSuccess.jsx
+++ b/src/components/EmailChangeSuccess.jsx
@@ -1,0 +1,47 @@
+import { CircleCheckBig, Mail } from 'lucide-react';
+
+const EmailChangeSuccess = ({email, closeModal}) => {
+  return (
+    <section className="bg-base-100 p-6 rounded-lg min-w-lg shadow-lg">
+      <div className="flex justify-center flex-col items-center space-y-4">
+        <div className='flex items-center justify-center w-12 h-12 rounded-full bg-emerald-200'>
+          <CircleCheckBig className='text-primary' />
+        </div>
+        
+        <div className='flex flex-col space-y-2 justify-center items-center'>
+          <h2 className="text-2xl font-bold">メールアドレスの変更が完了しました</h2>
+          <p className='text-neutral-500'>新しいメールアドレスでの認証が正常が完了しました</p>
+
+          <div className='bg-info rounded-lg flex items-center p-4 space-x-4 w-full mt-4'>
+            <Mail />
+            <div>
+              <p className='text-sm'>新しいメールアドレス</p>
+              <p className='text-sm'>{email}</p>
+            </div>
+          </div>
+
+          <div className='w-full mt-4'>
+            <p className='font-semibold'>次のステップ</p>
+            <ul className='mt-2 list-disc list-inside space-y-2'>
+              <li className='text-sm text-neutral-500'>今後のログインには新しいメールアドレスを使用してください</li>
+              <li className='text-sm text-neutral-500'>重要な通知は新しいメールアドレスに送信されます</li>
+              <li className='text-sm text-neutral-500'>セキュリティ設定の確認を勧めます</li>
+            </ul>
+          </div>
+
+          <div className='border-t-1 border-base-300 w-full mt-4'></div>
+
+          <button className='btn btn-neutral mt-4' onClick={closeModal}>閉じる</button>
+
+        </div>
+
+
+        
+      </div>
+      
+
+    </section>
+  )
+}
+
+export default EmailChangeSuccess;

--- a/src/components/MailTab.jsx
+++ b/src/components/MailTab.jsx
@@ -1,17 +1,30 @@
 import { Mail } from "lucide-react";
-import { useState } from "react";
+import { useActionState, useState } from "react";
+import { api } from '../utils/axios';
+import toast, { Toaster } from 'react-hot-toast';
 
 const MailTab = ({ email }) => {
-  const [formData, setFormData] = useState({
-    newEmail: "",
-    password: "",
-  })
 
-  const handleChange = (e) => {
-    setFormData((prev) => ({
-      ...prev, [e.target.name]: e.target.value
-    }))
-  }
+	const initialState = {
+		new_email: "",
+		password: ""
+	}
+
+
+	const [state, formAction, isPending] = useActionState(async (currentState, formData) => {
+		const data = Object.fromEntries(formData.entries());
+
+		try {
+					await api.post(`/email_change_requests`, {
+						new_email: data.newEmail,
+						password: data.password
+		})
+		toast.success('新しいメールアドレスに確認メールを送信しました')
+		} catch (err) {
+			console.log(err);
+			toast.error(err.response?.data?.message)
+		}
+	}, initialState)
 
 
 	return (
@@ -27,7 +40,7 @@ const MailTab = ({ email }) => {
 				</p>
 			</div>
 
-			<form>
+			<form action={formAction}>
 				<fieldset className="fieldset space-y-4">
 					<div>
 						<label htmlFor="" className="label text-sm">
@@ -37,9 +50,9 @@ const MailTab = ({ email }) => {
 							type="email"
 							placeholder="現在のパスワードを入力"
 							className="input w-full"
-							name="oldMail"
 							value={email}
 							disabled={true}
+
 						/>
 					</div>
 
@@ -52,8 +65,6 @@ const MailTab = ({ email }) => {
 							placeholder="new-email@example.com"
 							className="input w-full"
 							name="newEmail"
-              value={formData.newEmail}
-              onChange={handleChange}
 						/>
 					</div>
 
@@ -66,16 +77,15 @@ const MailTab = ({ email }) => {
 							placeholder="現在のパスワードを入力"
 							className="input w-full"
 							name="password"
-              value={formData.password}
-              onChange={handleChange}
 						/>
 					</div>
 
-					<button className="btn btn-primary" type="submit">
-						メールアドレスを変更
+					<button className="btn btn-primary" type="submit" disabled={isPending} >
+						{isPending ? <span className="loading loading-spinner loading-xs"></span> : "メールアドレスを変更"}
 					</button>
 				</fieldset>
 			</form>
+			<Toaster />
 		</section>
 	);
 };

--- a/src/pages/Top/Top.jsx
+++ b/src/pages/Top/Top.jsx
@@ -1,7 +1,35 @@
-import { useNavigate } from "react-router";
+import { useLoaderData, useLocation, useNavigate } from "react-router";
+import useModal from "../../hooks/useModal";
+import { useEffect, useState } from "react";
+import { api } from "../../utils/axios";
+import EmailChangeSuccess from "../../components/EmailChangeSuccess";
 
 const Top = () => {
 	const navigation = useNavigate();
+	const { Modal, openModal, closeModal } = useModal();
+	const location = useLocation();
+	const [email, setEmail] = useState("");
+
+	useEffect(() => {
+		const changeMail = async () => {
+			try {
+				const params = new URLSearchParams(location.search);
+			const token = params.get("token");
+
+			if (token) {
+				const response = await api.get(`/email_change_requests/confirm`, {
+				params: { token },
+			})
+			setEmail(response.data?.email);
+			openModal();
+			navigation(location.pathname, { replace: true })
+		}} catch (err) {
+			console.error(err);
+		}
+	}
+	changeMail();
+	}, [location.search]);
+
 	return (
 		<>
 			<main className="max-w-screen mx-auto flex flex-col items-center py-32 space-y-12">
@@ -23,6 +51,9 @@ const Top = () => {
 						今すぐ使ってみる
 					</button>
 				</div>
+				<Modal>
+					<EmailChangeSuccess email={email} closeModal={closeModal} />
+				</Modal>
 			</main>
 		</>
 	);


### PR DESCRIPTION
メールアドレス変更のリンクをクリックするとTOP画面に飛んで変更完了のモーダルが表示されるように
機能を実装した。

仕組みとしては変更のリンクにtokenをクエリパラメーター格納し、useEffectでlocation.searchを
依存配列する。
クエリパラメーターが含まれる場合はlocation.searchの値（クエリパラメーター）をnew URLSearchで
URLSearchオブジェクトにする。getメソッドでクエリの値を取得できる。
これをtokenに格納し、if文でtokenがある場合はメールアドレス変更のAPIをtokenとリクエストする。

リクエストが成功した後はnavigation(location.pathname, { replace: true})でURLのクエリパラメーターを消す。