### PR TITLE
ページ遷移中のローディング画面実装

### DIFF
--- a/src/Layout.jsx
+++ b/src/Layout.jsx
@@ -1,14 +1,23 @@
-import { Outlet } from "react-router";
+import { Outlet, useNavigation } from "react-router";
 import Footer from "./components/Footer";
 import Navibar from "./components/Navibar";
 import { UserProvider } from "./context/UserContext";
 
+
 const Layout = () => {
+	const navigation = useNavigation();
+	const isNavigating = Boolean(navigation.location);
+
 	return (
 		<>
 			<div className="flex flex-col min-h-screen">
 				<UserProvider>
 					<Navibar />
+					{isNavigating && (
+						<div className="fixed inset-0 flex items-center justify-center bg-base-300/50 z-50">
+  						<span className="loading loading-dots loading-xl"></span>
+						</div>
+					)}
 					<div className="flex-grow">
 						<Outlet />
 					</div>
@@ -17,7 +26,6 @@ const Layout = () => {
 			</div>
 		</>
 	);
-	l;
 };
 
 export default Layout;


### PR DESCRIPTION
useNavigationで画面遷移の状態を取得できる。
なお、useNavigateとは異なるので注意！

navigation.locationで遷移状態を取得しており、boolean値に変換して
非表示を切り替えている。