### PR TITLE
フィルターバグ、買い物リストのバグを修正

### DIFF
--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -10,7 +10,7 @@ interface OptimizedImageProps {
   priority?: boolean;
 }
 
-const OptimizedImage: React.FC<OptimizedImageProps> = ({
+const OptimizedImage = ({
   src,
   alt,
   className = '',
@@ -18,7 +18,7 @@ const OptimizedImage: React.FC<OptimizedImageProps> = ({
   height = 300,
   quality = 80,
   priority = false,
-}) => {
+}: OptimizedImageProps) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasError, setHasError] = useState(false);
 

--- a/src/components/ShoppingCard.tsx
+++ b/src/components/ShoppingCard.tsx
@@ -24,7 +24,7 @@ const ShoppingCard = ({
 			await api.delete<{ status: string; message: string }>(
 				`/shopping_lists/${id}`,
 			);
-			setLists((prevList) => prevList.filter((list) => Number(list.id) !== id));
+			setLists((prevList) => prevList.filter((list) => list.id !== id));
 			toast.success("買い物リストを削除しました");
 		} catch (error) {
 			console.log(error);

--- a/src/pages/VegeList/VegeList.tsx
+++ b/src/pages/VegeList/VegeList.tsx
@@ -12,9 +12,9 @@ const VegeList = () => {
 	const { data: vegetables, meta } = loaderData;
 	const { total_pages, current_page } = meta;
 	const [searchParams, setSearchParams] = useSearchParams();
-	const [searchText, setSearchText] = useState<string>("");
-	const [isInSeason, setIsInSeason] = useState<boolean>(false);
-	const [isDiscounted, setIsDiscounted] = useState<boolean>(false);
+	const [searchText, setSearchText] = useState<string>(searchParams.get('keyword') || '');
+	const [isInSeason, setIsInSeason] = useState<boolean>(searchParams.get('season') === 'true');
+	const [isDiscounted, setIsDiscounted] = useState<boolean>(searchParams.get('discounted') === 'true');
 	const { vegeNames } = useVegeNames();
 	const [filteredNames, setFilteredNames] = useState<string[]>([]);
 	const [isDropdownVisible, setIsDropdownVisible] = useState<boolean>(false);
@@ -163,6 +163,7 @@ const VegeList = () => {
 								animationFillMode: "both",
 							}}
 						>
+
 							<Card
 								id={vegetable.attributes.id}
 								name={vegetable.attributes.name}


### PR DESCRIPTION
以下の二つのバグについて修正を行なった

１買い物リストの削除ボタンを押してもリストが残ったまま（再読み込みすると消える）
リストを削除する関数内のfilterメソッドでNumberでnumberに変換していたが、そもそもの値がnumberなので
変換する必要がない。再度number型に変換することで投下演算子が正しく計算されずにリストが削除されていなかった。
（API処理自体は正しく処理されているので、リロードすると該当のリストは消えた）
そのため、Numberの変換処理を削除してバグは修正された。


２vegelistの画面でフィルターをかけて、表示された野菜詳細ページに移動、ブラウザバックで戻ると
画面上はフィルターのかかった野菜が表示されるが、画面上はフィルタースイッチがONになっていない状態になっていた。

原因はフィルターの状態管理をするuseStateの初期値がuseState(false)になっていたこと
これにより表示された際にfalseになってしまい、クエリパラメーターとの整合性が崩れていた。
そのため、初期値はsearchParams.get(' key' || '')とすることでキーがある場合はその値を返し、ない場合は
空欄で返すように変更した。
これによりブラウザバックした際にもキーがあれば正しく状態を画面に反映するようできた。