### PR TITLE
fix: フリッジアイテムの編集機能の状態管理を改善

### DIFF
--- a/src/pages/FridgeItems/FridgeItems.tsx
+++ b/src/pages/FridgeItems/FridgeItems.tsx
@@ -61,7 +61,7 @@ const FridgeItems = () => {
 	const [recipe, setRecipe] = useState<RecipeResponse | null>(null);
 	const [isPending, startTransition] = useTransition();
 	const { Modal, openModal, closeModal } = useModal();
-	const [editingItemId, setEditingItemId] = useState<number | null>(null);
+	const [editingItemId, setEditingItemId] = useState<number | undefined>(undefined);
 	const editItem = items.filter((item) => item.id === editingItemId);
 	const [sortKey, setSortKey] = useState<
 		| "category"

--- a/src/test/components/AddFridgeItemForm.test.tsx
+++ b/src/test/components/AddFridgeItemForm.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import AddFridgeItemForm from '../../components/AddFridgeItemForm';
+
+describe('AddFridgeItemForm', () => {
+  describe('正常系', () => {
+    const defaultProps = {
+      closeModel: closeModel;
+    }
+    beforeEach(() => {
+      render(<AddFridgeItemForm {...defaultProps} />);
+    })
+  })
+})

--- a/src/types/apiResponse.ts
+++ b/src/types/apiResponse.ts
@@ -1,3 +1,5 @@
+import { LucideProps } from "lucide-react";
+
 export interface ShoppingItem {
 	id: number;
 	name: string;
@@ -150,13 +152,13 @@ export interface CardProps {
 
 interface Category {
 	name: string;
-	icon: string;
+	icon: React.ForwardRefExoticComponent<Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>>;
 }
 
 export interface FridgeItemFormProps {
 	closeModal: () => void;
 	categories: Category[];
-	id: number;
+	id?: number;
 	item: FridgeItem;
 	handleEdit: ({
 		id,


### PR DESCRIPTION
- editingItemIdの初期値をnullからundefinedに変更
- apiResponse.tsでCategoryインターフェースのiconプロパティの型を修正
- FridgeItemFormPropsインターフェースのidプロパティをオプショナルに変更
- AddFridgeItemFormのテストファイルを新規作成
- <!-- I want to review in Japanese. -->