### PR TITLE
fix: 食材情報の更新メッセージを修正し、日付の処理を改善

### DIFF
--- a/src/components/AddFridgeItemForm.tsx
+++ b/src/components/AddFridgeItemForm.tsx
@@ -15,8 +15,8 @@ const AddFridgeItemForm = ({
 	const [name, setName] = useState<string>("");
 	const [amount, setAmount] = useState<string>("");
 	const [category, setCategory] = useState<string>("");
-	const [date, setDate] = useState<Date | null>(null);
-	const itemCategories = categories.filter((ct) => ct.name !== "全て");
+	const [date, setDate] = useState<Date | undefined>(undefined);
+	const itemCategories = (categories.filter((ct) => ct.name !== "全て")) 
 
 	const handleDateChange = (selectedDate: Date) => {
 		setDate(selectedDate);

--- a/src/components/EditFridgeItemForm.tsx
+++ b/src/components/EditFridgeItemForm.tsx
@@ -100,7 +100,7 @@ const EditFridgeItemForm = ({
 							className="btn"
 							onClick={() => handleEdit({ id, name, category, amount, date })}
 						>
-							編集
+							更新
 						</button>
 					</div>
 				</div>

--- a/src/pages/FridgeItems/FridgeItems.tsx
+++ b/src/pages/FridgeItems/FridgeItems.tsx
@@ -189,16 +189,16 @@ const FridgeItems = () => {
 						name: name,
 						category: category,
 						display_amount: amount,
-						expire_date: date,
+						expire_date: date.toLocaleDateString(),
 					},
 				},
 			);
 			setItems(response.data.data);
 			closeModal();
-			toast.success("食材情報を編集しました");
+			toast.success("食材情報を更新しました");
 		} catch (err) {
 			console.error(err);
-			toast.error("食材情報の編集に失敗しました");
+			toast.error("食材情報の更新に失敗しました");
 		}
 	};
 
@@ -627,7 +627,7 @@ const FridgeItems = () => {
 						closeModal={closeModal}
 						categories={categories}
 						id={editingItemId}
-						item={editItem[0]?.attributes || null}
+						item={editItem[0]?.attributes || undefined}
 						handleEdit={handleEdit}
 						handleAdd={handleAdd}
 					/>

--- a/src/test/components/AddFridgeItemForm.test.tsx
+++ b/src/test/components/AddFridgeItemForm.test.tsx
@@ -1,13 +1,36 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import AddFridgeItemForm from '../../components/AddFridgeItemForm';
+import userEvent from '@testing-library/user-event';
 
 describe('AddFridgeItemForm', () => {
   describe('正常系', () => {
     const defaultProps = {
-      closeModel: closeModel;
+      closeModal: vi.fn(),
+      categories: [
+        { name: '全て', icon: 'all' },
+        { name: '野菜', icon: 'veg' },
+        { name: '果物', icon: 'fruit' }
+      ],
+      handleAdd: vi.fn(),
     }
     beforeEach(() => {
+      vi.clearAllMocks();
       render(<AddFridgeItemForm {...defaultProps} />);
+    })
+    it('初期表示の確認', () => {
+      expect(screen.getByRole('heading', { name: '食材を追加'})).toBeInTheDocument();
+      expect(screen.getByText('食材の情報を入力してください')).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'カテゴリを選択してください' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '賞味期限を選択してください'})).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'キャンセル' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
+    });
+
+    it('食材情報の入力が正しく反映される', async () => {
+      const user = userEvent.setup();
+      const inputIngredient = screen.getByPlaceholderText('食材名');
+      await user.type(inputIngredient, '人参');
+      expect(inputIngredient).toHaveValue('人参');
     })
   })
 })

--- a/src/types/apiResponse.ts
+++ b/src/types/apiResponse.ts
@@ -1,4 +1,4 @@
-import { LucideProps } from "lucide-react";
+import { LucideIcon, LucideProps } from "lucide-react";
 
 export interface ShoppingItem {
 	id: number;
@@ -152,14 +152,14 @@ export interface CardProps {
 
 interface Category {
 	name: string;
-	icon: React.ForwardRefExoticComponent<Omit<LucideProps, "ref"> & React.RefAttributes<SVGSVGElement>>;
+	icon: LucideIcon;
 }
 
 export interface FridgeItemFormProps {
 	closeModal: () => void;
 	categories: Category[];
 	id?: number;
-	item: FridgeItem;
+	item?: FridgeItem;
 	handleEdit: ({
 		id,
 		name,


### PR DESCRIPTION
- AddFridgeItemForm: 日付の初期値をnullからundefinedに変更
- EditFridgeItemForm: ボタンのラベルを「編集」から「更新」に変更
- FridgeItems: 食材情報の更新メッセージを修正し、日付を文字列形式で保存
- apiResponse: アイコンの型をLucideIconに変更
- AddFridgeItemForm.test: テストケースを追加し、初期表示の確認を実装