### PR TITLE
feat: CSRFトークンの設定をaxiosインスタンスに追加

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useEffect, useState } from "react";
-import { api } from "../utils/axios";
+import React, { createContext, use, useEffect, useState } from "react";
+import { api, setCsrfToken } from "../utils/axios";
+import { AxiosResponse } from "axios";
 
 interface UserProps {
 	logged_in?: boolean;

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,7 +1,37 @@
 import axios, { type AxiosInstance } from "axios";
 
+let csrfToken: string | undefined
+
+export const setCsrfToken = (token: string | undefined) => {
+	csrfToken = token;
+};
+
+
 export const api: AxiosInstance = axios.create({
 	baseURL: `${import.meta.env.VITE_RAILS_API}`,
 	withCredentials: true,
 	timeout: 30000,
 });
+
+api.interceptors.request.use((config) => {
+	if (csrfToken) {
+		config.headers['X-CSRF-Token'] = csrfToken;
+	}
+	return config;
+});
+
+api.interceptors.response.use((response) => {
+	const newToken = response.headers['x-csrf-token'];
+	if (newToken) {
+		setCsrfToken(newToken);
+	}
+	return response;
+},
+(error) => {
+	const newToken = error.response?.headers['x-csrf-token'];
+	if (newToken) {
+		setCsrfToken(newToken);
+	}
+	return Promise.reject(error);
+}
+)


### PR DESCRIPTION
- axiosのリクエストおよびレスポンスインターセプターを追加し、CSRFトークンを設定
- UserContextでのインポートを整理


現状の認証・認可のシステムはcookieベースのjwtトークン認証を採用している。
そのため、xss攻撃には耐性があるが、csrf攻撃に脆弱性があるため、csrfトークンを実装した。

仕組みとしてはaxiosのinteceptorsの機能を使用して、レスポンスのたびにx-csrf-tokenのheaderを
確認して、変数に代入、リクエストの際に、headerに入れて送信する機能を実装した。
これにより、リクエストのたびにcsrf-token認証が行われる。