### PR TITLE
chore: dependabot設定ファイルの追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull_requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
- npmおよびGitHub Actionsの依存関係を毎日更新する設定を追加
- 各エコシステムのオープンプルリクエストの制限を10に設定