### PR TITLE
fix: dependabot設定ファイルのプロパティ名を修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull_requests-limit: 10
+  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
- open-pull_requests-limitをopen-pull-requests-limitに修正